### PR TITLE
Audit comments

### DIFF
--- a/src/SingletonPaymasterV6.sol
+++ b/src/SingletonPaymasterV6.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.26;
 
 import { UserOperation } from "@account-abstraction-v6/interfaces/IPaymaster.sol";
-import { IEntryPoint } from "@account-abstraction-v6/interfaces/IEntryPoint.sol";
 import { _packValidationData } from "@account-abstraction-v6/core/Helpers.sol";
 
 import { ECDSA } from "@openzeppelin-v5.0.2/contracts/utils/cryptography/ECDSA.sol";

--- a/src/SingletonPaymasterV6.sol
+++ b/src/SingletonPaymasterV6.sol
@@ -200,9 +200,8 @@ contract SingletonPaymasterV6 is BaseSingletonPaymaster, IPaymasterV6 {
 
         uint256 actualUserOpFeePerGas = _calculateActualUserOpFeePerGas(ctx.maxFeePerGas, ctx.maxPriorityFeePerGas);
 
-        uint256 costInToken = getCostInToken(
-            _actualGasCost / actualUserOpFeePerGas, ctx.postOpGas, actualUserOpFeePerGas, ctx.exchangeRate
-        ) + ctx.constantFee;
+        uint256 costInToken =
+            getCostInToken(_actualGasCost, ctx.postOpGas, actualUserOpFeePerGas, ctx.exchangeRate) + ctx.constantFee;
 
         // There is a bug in EntryPoint v0.6 where if postOp reverts where the revert bytes are less than 32bytes,
         // it will revert the whole bundle instead of just force failing the userOperation.

--- a/src/SingletonPaymasterV6.sol
+++ b/src/SingletonPaymasterV6.sol
@@ -50,14 +50,14 @@ contract SingletonPaymasterV6 is BaseSingletonPaymaster, IPaymasterV6 {
     function validatePaymasterUserOp(
         UserOperation calldata userOp,
         bytes32 userOpHash,
-        uint256 maxCost
+        uint256 requiredPreFund
     )
         external
         override
         returns (bytes memory context, uint256 validationData)
     {
         _requireFromEntryPoint();
-        return _validatePaymasterUserOp(userOp, userOpHash, maxCost);
+        return _validatePaymasterUserOp(userOp, userOpHash, requiredPreFund);
     }
 
     /// @inheritdoc IPaymasterV6
@@ -98,7 +98,7 @@ contract SingletonPaymasterV6 is BaseSingletonPaymaster, IPaymasterV6 {
     function _validatePaymasterUserOp(
         UserOperation calldata _userOp,
         bytes32 _userOpHash,
-        uint256 /* maxCost */
+        uint256 _requiredPreFund
     )
         internal
         returns (bytes memory, uint256)
@@ -122,7 +122,7 @@ contract SingletonPaymasterV6 is BaseSingletonPaymaster, IPaymasterV6 {
         }
 
         if (mode == ERC20_MODE) {
-            (context, validationData) = _validateERC20Mode(_userOp, paymasterConfig, _userOpHash);
+            (context, validationData) = _validateERC20Mode(_userOp, paymasterConfig, _userOpHash, _requiredPreFund);
         }
 
         return (context, validationData);
@@ -165,7 +165,8 @@ contract SingletonPaymasterV6 is BaseSingletonPaymaster, IPaymasterV6 {
     function _validateERC20Mode(
         UserOperation calldata _userOp,
         bytes calldata _paymasterConfig,
-        bytes32 _userOpHash
+        bytes32 _userOpHash,
+        uint256 _requiredPreFund
     )
         internal
         view
@@ -179,7 +180,7 @@ contract SingletonPaymasterV6 is BaseSingletonPaymaster, IPaymasterV6 {
         bool isSignatureValid = signers[recoveredSigner];
         uint256 validationData = _packValidationData(!isSignatureValid, cfg.validUntil, cfg.validAfter);
 
-        bytes memory context = _createPostOpContext(_userOp, _userOpHash, cfg);
+        bytes memory context = _createPostOpContext(_userOp, _userOpHash, cfg, _requiredPreFund);
         return (context, validationData);
     }
 

--- a/src/SingletonPaymasterV6.sol
+++ b/src/SingletonPaymasterV6.sol
@@ -313,6 +313,6 @@ contract SingletonPaymasterV6 is BaseSingletonPaymaster, IPaymasterV6 {
             )
         );
 
-        return keccak256(abi.encode(userOpHash, block.chainid, address(this)));
+        return keccak256(abi.encode(userOpHash, block.chainid));
     }
 }

--- a/src/SingletonPaymasterV7.sol
+++ b/src/SingletonPaymasterV7.sol
@@ -325,6 +325,6 @@ contract SingletonPaymasterV7 is BaseSingletonPaymaster, IPaymasterV7 {
             )
         );
 
-        return keccak256(abi.encode(userOpHash, block.chainid, address(this)));
+        return keccak256(abi.encode(userOpHash, block.chainid));
     }
 }

--- a/src/SingletonPaymasterV7.sol
+++ b/src/SingletonPaymasterV7.sol
@@ -55,14 +55,14 @@ contract SingletonPaymasterV7 is BaseSingletonPaymaster, IPaymasterV7 {
     function validatePaymasterUserOp(
         PackedUserOperation calldata userOp,
         bytes32 userOpHash,
-        uint256 maxCost
+        uint256 requiredPreFund
     )
         external
         override
         returns (bytes memory context, uint256 validationData)
     {
         _requireFromEntryPoint();
-        return _validatePaymasterUserOp(userOp, userOpHash, maxCost);
+        return _validatePaymasterUserOp(userOp, userOpHash, requiredPreFund);
     }
 
     /// @inheritdoc IPaymasterV7
@@ -116,7 +116,7 @@ contract SingletonPaymasterV7 is BaseSingletonPaymaster, IPaymasterV7 {
     function _validatePaymasterUserOp(
         PackedUserOperation calldata _userOp,
         bytes32 _userOpHash,
-        uint256 /* maxCost */
+        uint256 _requiredPreFund
     )
         internal
         returns (bytes memory, uint256)
@@ -140,7 +140,8 @@ contract SingletonPaymasterV7 is BaseSingletonPaymaster, IPaymasterV7 {
         }
 
         if (mode == ERC20_MODE) {
-            (context, validationData) = _validateERC20Mode(mode, _userOp, paymasterConfig, _userOpHash);
+            (context, validationData) =
+                _validateERC20Mode(mode, _userOp, paymasterConfig, _userOpHash, _requiredPreFund);
         }
 
         return (context, validationData);
@@ -184,7 +185,8 @@ contract SingletonPaymasterV7 is BaseSingletonPaymaster, IPaymasterV7 {
         uint8 _mode,
         PackedUserOperation calldata _userOp,
         bytes calldata _paymasterConfig,
-        bytes32 _userOpHash
+        bytes32 _userOpHash,
+        uint256 _requiredPreFund
     )
         internal
         view
@@ -198,7 +200,7 @@ contract SingletonPaymasterV7 is BaseSingletonPaymaster, IPaymasterV7 {
         bool isSignatureValid = signers[recoveredSigner];
         uint256 validationData = _packValidationData(!isSignatureValid, cfg.validUntil, cfg.validAfter);
 
-        bytes memory context = _createPostOpContext(_userOp, _userOpHash, cfg);
+        bytes memory context = _createPostOpContext(_userOp, _userOpHash, cfg, _requiredPreFund);
         return (context, validationData);
     }
 

--- a/src/SingletonPaymasterV7.sol
+++ b/src/SingletonPaymasterV7.sol
@@ -99,7 +99,8 @@ contract SingletonPaymasterV7 is BaseSingletonPaymaster, IPaymasterV7 {
      * - paymaster verification gas (16 bytes)
      * - paymaster postop gas (16 bytes)
      * - mode and allowAllBundlers (1 byte) - lowest bit represents allowAllBundlers, rest of the bits represent mode
-     * - constantFeePresent and recipientPresent (1 byte) - 000000{recipientPresent bit}{constantFeePresent bit}
+     * - constantFeePresent and recipientPresent and preFundPresent (1 byte) - 00000{preFundPresent
+     * bit}{recipientPresent bit}{constantFeePresent bit}
      * - validUntil (6 bytes)
      * - validAfter (6 bytes)
      * - token address (20 bytes)
@@ -107,6 +108,7 @@ contract SingletonPaymasterV7 is BaseSingletonPaymaster, IPaymasterV7 {
      * - exchangeRate (32 bytes)
      * - paymasterValidationGasLimit (16 bytes)
      * - treasury (20 bytes)
+     * - preFund (16 bytes) - only if preFundPresent is 1
      * - constantFee (16 bytes - only if constantFeePresent is 1)
      * - recipient (20 bytes - only if recipientPresent is 1)
      * - signature (64 or 65 bytes)
@@ -189,7 +191,6 @@ contract SingletonPaymasterV7 is BaseSingletonPaymaster, IPaymasterV7 {
         uint256 _requiredPreFund
     )
         internal
-        view
         returns (bytes memory, uint256)
     {
         ERC20PaymasterData memory cfg = _parseErc20Config(_paymasterConfig);
@@ -199,8 +200,22 @@ contract SingletonPaymasterV7 is BaseSingletonPaymaster, IPaymasterV7 {
 
         bool isSignatureValid = signers[recoveredSigner];
         uint256 validationData = _packValidationData(!isSignatureValid, cfg.validUntil, cfg.validAfter);
-
         bytes memory context = _createPostOpContext(_userOp, _userOpHash, cfg, _requiredPreFund);
+
+        if (!isSignatureValid) {
+            return (context, validationData);
+        }
+
+        uint256 costInToken = getCostInToken(_requiredPreFund, 0, 0, cfg.exchangeRate);
+
+        if (cfg.preFundInToken > costInToken) {
+            revert PreFundTooHigh();
+        }
+
+        if (cfg.preFundInToken > 0) {
+            SafeTransferLib.safeTransferFrom(cfg.token, _userOp.sender, cfg.treasury, cfg.preFundInToken);
+        }
+
         return (context, validationData);
     }
 
@@ -251,7 +266,16 @@ contract SingletonPaymasterV7 is BaseSingletonPaymaster, IPaymasterV7 {
         uint256 costInToken =
             getCostInToken(actualGasCost, ctx.postOpGas, _actualUserOpFeePerGas, ctx.exchangeRate) + ctx.constantFee;
 
-        SafeTransferLib.safeTransferFrom(ctx.token, ctx.sender, ctx.treasury, costInToken);
+        uint256 absoluteCostInToken =
+            costInToken > ctx.preFundCharged ? costInToken - ctx.preFundCharged : ctx.preFundCharged - costInToken;
+
+        SafeTransferLib.safeTransferFrom(
+            ctx.token,
+            costInToken > ctx.preFundCharged ? ctx.sender : ctx.treasury,
+            costInToken > ctx.preFundCharged ? ctx.treasury : ctx.sender,
+            absoluteCostInToken
+        );
+
         uint256 preFundInToken = ctx.preFund * ctx.exchangeRate / 1e18;
 
         if (ctx.recipient != address(0) && preFundInToken > costInToken) {
@@ -283,6 +307,12 @@ contract SingletonPaymasterV7 is BaseSingletonPaymaster, IPaymasterV7 {
             bool constantFeePresent = (combinedByte & 0x01) != 0;
             // recipientPresent is in the second lowest bit
             bool recipientPresent = (combinedByte & 0x02) != 0;
+            // preFundPresent is in the third lowest bit
+            bool preFundPresent = (combinedByte & 0x04) != 0;
+
+            if (preFundPresent) {
+                paymasterDataLength += 16;
+            }
 
             if (constantFeePresent) {
                 paymasterDataLength += 16;

--- a/src/SingletonPaymasterV7.sol
+++ b/src/SingletonPaymasterV7.sol
@@ -2,14 +2,11 @@
 pragma solidity ^0.8.26;
 
 import { PackedUserOperation } from "@account-abstraction-v7/interfaces/PackedUserOperation.sol";
-import { IEntryPoint } from "@account-abstraction-v7/interfaces/IEntryPoint.sol";
 import { _packValidationData } from "@account-abstraction-v7/core/Helpers.sol";
 import { UserOperationLib } from "@account-abstraction-v7/core/UserOperationLib.sol";
-import { UserOperationLib as UserOperationLibV07 } from "@account-abstraction-v7/core/UserOperationLib.sol";
 
 import { ECDSA } from "@openzeppelin-v5.0.2/contracts/utils/cryptography/ECDSA.sol";
 import { MessageHashUtils } from "@openzeppelin-v5.0.2/contracts/utils/cryptography/MessageHashUtils.sol";
-import { Math } from "@openzeppelin-v5.0.2/contracts/utils/math/Math.sol";
 
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 
@@ -33,8 +30,8 @@ contract SingletonPaymasterV7 is BaseSingletonPaymaster, IPaymasterV7 {
     /*                  CONSTANTS AND IMMUTABLES                  */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
-    uint256 private immutable PAYMASTER_DATA_OFFSET = UserOperationLibV07.PAYMASTER_DATA_OFFSET;
-    uint256 private immutable PAYMASTER_VALIDATION_GAS_OFFSET = UserOperationLibV07.PAYMASTER_VALIDATION_GAS_OFFSET;
+    uint256 private immutable PAYMASTER_DATA_OFFSET = UserOperationLib.PAYMASTER_DATA_OFFSET;
+    uint256 private immutable PAYMASTER_VALIDATION_GAS_OFFSET = UserOperationLib.PAYMASTER_VALIDATION_GAS_OFFSET;
     uint256 private constant PENALTY_PERCENT = 10;
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/src/base/BasePaymaster.sol
+++ b/src/base/BasePaymaster.sol
@@ -4,10 +4,7 @@ pragma solidity ^0.8.0;
 /* solhint-disable reason-string */
 
 import { ManagerAccessControl } from "./ManagerAccessControl.sol";
-import { IManagerAccessControl } from "./ManagerAccessControl.sol";
-import { IERC165 } from "@openzeppelin-v5.0.2/contracts/utils/introspection/IERC165.sol";
 import { IEntryPoint } from "@account-abstraction-v7/interfaces/IEntryPoint.sol";
-import { MultiSigner } from "./MultiSigner.sol";
 
 /**
  * Helper class for creating a paymaster.

--- a/src/base/BaseSingletonPaymaster.sol
+++ b/src/base/BaseSingletonPaymaster.sol
@@ -3,8 +3,6 @@ pragma solidity ^0.8.0;
 
 /* solhint-disable reason-string */
 import { BasePaymaster } from "./BasePaymaster.sol";
-import { IPaymasterV6 } from "../interfaces/IPaymasterV6.sol";
-import { PostOpMode } from "../interfaces/PostOpMode.sol";
 import { MultiSigner } from "./MultiSigner.sol";
 
 import { UserOperation } from "@account-abstraction-v6/interfaces/IPaymaster.sol";
@@ -12,12 +10,6 @@ import { UserOperationLib } from "@account-abstraction-v7/core/UserOperationLib.
 import { PackedUserOperation } from "@account-abstraction-v7/interfaces/PackedUserOperation.sol";
 
 import { ManagerAccessControl } from "./ManagerAccessControl.sol";
-import { IManagerAccessControl } from "./ManagerAccessControl.sol";
-import { ECDSA } from "@openzeppelin-v5.0.2/contracts/utils/cryptography/ECDSA.sol";
-import { MessageHashUtils } from "@openzeppelin-v5.0.2/contracts/utils/cryptography/MessageHashUtils.sol";
-
-import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
-import { SignatureCheckerLib } from "solady/utils/SignatureCheckerLib.sol";
 
 using UserOperationLib for PackedUserOperation;
 

--- a/src/base/MultiSigner.sol
+++ b/src/base/MultiSigner.sol
@@ -4,9 +4,6 @@ pragma solidity ^0.8.0;
 /* solhint-disable reason-string */
 
 import { ManagerAccessControl } from "./ManagerAccessControl.sol";
-import { IManagerAccessControl } from "./ManagerAccessControl.sol";
-import { IERC165 } from "@openzeppelin-v5.0.2/contracts/utils/introspection/IERC165.sol";
-import { IEntryPoint } from "@account-abstraction-v7/interfaces/IEntryPoint.sol";
 
 /**
  * Helper class for creating a contract with multiple valid signers.

--- a/src/interfaces/IPaymasterV6.sol
+++ b/src/interfaces/IPaymasterV6.sol
@@ -17,7 +17,7 @@ interface IPaymasterV6 {
      * The paymaster pre-pays using its deposit, and receive back a refund after the postOp method returns.
      * @param userOp the user operation
      * @param userOpHash hash of the user's request data.
-     * @param maxCost the maximum cost of this transaction (based on maximum gas and gas price from userOp)
+     * @param requiredPreFund the maximum cost of this transaction (based on maximum gas and gas price from userOp)
      * @return context value to send to a postOp
      *      zero length to signify postOp is not required.
      * @return validationData signature and time-range of this operation, encoded the same as the return value of
@@ -31,7 +31,7 @@ interface IPaymasterV6 {
     function validatePaymasterUserOp(
         UserOperation calldata userOp,
         bytes32 userOpHash,
-        uint256 maxCost
+        uint256 requiredPreFund
     )
         external
         returns (bytes memory context, uint256 validationData);

--- a/src/interfaces/IPaymasterV6.sol
+++ b/src/interfaces/IPaymasterV6.sol
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {
-    UserOperationLib as UserOperationLibV06,
-    UserOperation
-} from "@account-abstraction-v6/interfaces/UserOperation.sol";
+import { UserOperation } from "@account-abstraction-v6/interfaces/UserOperation.sol";
 import { PostOpMode } from "./PostOpMode.sol";
 
 /**

--- a/src/interfaces/IPaymasterV7.sol
+++ b/src/interfaces/IPaymasterV7.sol
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {
-    UserOperationLib as UserOperationLibV07,
-    PackedUserOperation
-} from "@account-abstraction-v7/core/UserOperationLib.sol";
+import { PackedUserOperation } from "@account-abstraction-v7/core/UserOperationLib.sol";
 import { PostOpMode } from "./PostOpMode.sol";
 
 /**

--- a/test/SingletonPaymasterV6.t.sol
+++ b/test/SingletonPaymasterV6.t.sol
@@ -583,7 +583,7 @@ contract SingletonPaymasterV6Test is Test {
         uint256 actualGasCost = userOperationGasUsed * actualUserOpFeePerGas;
 
         uint256 expectedCostInToken =
-            paymaster.getCostInToken(userOperationGasUsed, postOpGas, actualUserOpFeePerGas, exchangeRate);
+            paymaster.getCostInToken(actualGasCost, postOpGas, actualUserOpFeePerGas, exchangeRate);
 
         setupERC20Environment(expectedCostInToken);
 
@@ -795,7 +795,7 @@ contract SingletonPaymasterV6Test is Test {
         vm.prank(address(entryPoint));
         paymaster.postOp(PostOpMode.opSucceeded, context, actualGasCost);
         uint256 expectedCostInTokenWithoutConstantFee =
-            paymaster.getCostInToken(userOperationGasUsed, postOpGas, actualUserOpFeePerGas, exchangeRate);
+            paymaster.getCostInToken(actualGasCost, postOpGas, actualUserOpFeePerGas, exchangeRate);
 
         uint256 expectedCostInToken = constantFeePresent == 1
             ? expectedCostInTokenWithoutConstantFee + constantFee

--- a/test/SingletonPaymasterV7.t.sol
+++ b/test/SingletonPaymasterV7.t.sol
@@ -110,7 +110,7 @@ contract SingletonPaymasterV7Test is Test {
         assertEq(token.balanceOf(treasury), 0);
 
         PackedUserOperation memory op = fillUserOp();
-        op.paymasterAndData = getSignedPaymasterData(ERC20_MODE, ALLOW_ALL_BUNDLERS, op, uint8(0), uint8(0));
+        op.paymasterAndData = getSignedPaymasterData(ERC20_MODE, ALLOW_ALL_BUNDLERS, op, uint8(0), uint8(0), uint8(0));
         op.signature = signUserOp(op, userKey);
 
         // check that UserOperationSponsored log is emitted.
@@ -133,7 +133,7 @@ contract SingletonPaymasterV7Test is Test {
         assertEq(token.balanceOf(treasury), 0);
 
         PackedUserOperation memory op = fillUserOp();
-        op.paymasterAndData = getSignedPaymasterData(ERC20_MODE, ALLOW_ALL_BUNDLERS, op, uint8(1), uint8(0));
+        op.paymasterAndData = getSignedPaymasterData(ERC20_MODE, ALLOW_ALL_BUNDLERS, op, uint8(1), uint8(0), uint8(0));
         op.signature = signUserOp(op, userKey);
 
         // check that UserOperationSponsored log is emitted.
@@ -151,7 +151,8 @@ contract SingletonPaymasterV7Test is Test {
 
     function testVerifyingSuccess() external {
         PackedUserOperation memory op = fillUserOp();
-        op.paymasterAndData = getSignedPaymasterData(VERIFYING_MODE, ALLOW_ALL_BUNDLERS, op, uint8(0), uint8(0));
+        op.paymasterAndData =
+            getSignedPaymasterData(VERIFYING_MODE, ALLOW_ALL_BUNDLERS, op, uint8(0), uint8(0), uint8(0));
         op.signature = signUserOp(op, userKey);
 
         // check that UserOperationSponsored log is emitted.
@@ -159,6 +160,30 @@ contract SingletonPaymasterV7Test is Test {
         emit BaseSingletonPaymaster.UserOperationSponsored(getOpHash(op), op.sender, VERIFYING_MODE, address(0), 0, 0);
 
         submitUserOp(op);
+    }
+
+    function test_ERC20WithPrefund() external {
+        setupERC20Environment();
+
+        // treasury should have no tokens
+        assertEq(token.balanceOf(treasury), 0);
+
+        PackedUserOperation memory op = fillUserOp();
+        op.paymasterAndData =
+            getSignedPaymasterData(ERC20_MODE, ALLOW_ALL_BUNDLERS, op, uint8(0), uint8(0), uint128(1_000_000));
+        op.signature = signUserOp(op, userKey);
+
+        // check that UserOperationSponsored log is emitted.
+        // event data check is skipped because we don't know how much will be spent.
+        vm.expectEmit(true, true, true, false, address(paymaster));
+        emit BaseSingletonPaymaster.UserOperationSponsored(
+            getOpHash(op), op.sender, ERC20_MODE, address(token), 0, EXCHANGE_RATE
+        );
+
+        submitUserOp(op);
+
+        // treasury should now have tokens
+        assertGt(token.balanceOf(treasury), 0);
     }
 
     function test_RevertWhen_ERC20PaymasterSignatureInvalid() external {
@@ -176,7 +201,8 @@ contract SingletonPaymasterV7Test is Test {
             op,
             unauthorizedSignerKey,
             uint8(0),
-            uint8(0)
+            uint8(0),
+            uint128(0)
         );
         op.signature = signUserOp(op, userKey);
 
@@ -313,9 +339,16 @@ contract SingletonPaymasterV7Test is Test {
         submitUserOp(op);
     }
 
-    function test_RevertWhen_TokenAddressInvalid(uint8 _constantFeePresent, uint8 _recipientPresent) external {
+    function test_RevertWhen_TokenAddressInvalid(
+        uint8 _constantFeePresent,
+        uint8 _recipientPresent,
+        uint8 _preFundPresent
+    )
+        external
+    {
         uint8 constantFeePresent = uint8(bound(_constantFeePresent, 0, 1));
         uint8 recipientPresent = uint8(bound(_recipientPresent, 0, 1));
+        uint128 preFundPresent = uint128(bound(_preFundPresent, 0, 1));
         setupERC20Environment();
 
         PackedUserOperation memory op = fillUserOp();
@@ -325,7 +358,10 @@ contract SingletonPaymasterV7Test is Test {
             uint128(100_000), // paymaster verification gas
             uint128(50_000), // paymaster postop gas
             uint8((ALLOW_ALL_BUNDLERS & 0x01) | (ERC20_MODE << 1)),
-            uint8((constantFeePresent & 0x01) | (recipientPresent << 1)),
+            uint8(
+                (constantFeePresent == 1 ? 1 : 0) | (recipientPresent == 1 ? 1 << 1 : 0)
+                    | (preFundPresent > 0 ? 1 << 2 : 0)
+            ),
             uint48(0), // validUntil
             int48(0), // validAfter
             address(0), // token will throw here, token address cannot be zero
@@ -339,6 +375,13 @@ contract SingletonPaymasterV7Test is Test {
             uint128(0), // paymasterValidationGasLimit
             treasury // treasury
         );
+
+        if (preFundPresent > 0) {
+            op.paymasterAndData = abi.encodePacked(
+                op.paymasterAndData,
+                preFundPresent // preFund
+            );
+        }
 
         if (constantFeePresent == 1) {
             op.paymasterAndData = abi.encodePacked(
@@ -368,9 +411,17 @@ contract SingletonPaymasterV7Test is Test {
         submitUserOp(op);
     }
 
-    function test_RevertWhen_ExchangeRateInvalid(uint8 _constantFeePresent, uint8 _recipientPresent) external {
+    function test_RevertWhen_ExchangeRateInvalid(
+        uint8 _constantFeePresent,
+        uint8 _recipientPresent,
+        uint8 _preFundPresent
+    )
+        external
+    {
         uint8 constantFeePresent = uint8(bound(_constantFeePresent, 0, 1));
         uint8 recipientPresent = uint8(bound(_recipientPresent, 0, 1));
+        uint128 preFundPresent = uint128(bound(_preFundPresent, 0, 1));
+
         setupERC20Environment();
 
         PackedUserOperation memory op = fillUserOp();
@@ -380,7 +431,10 @@ contract SingletonPaymasterV7Test is Test {
             uint128(100_000), // paymaster verification gas
             uint128(50_000), // paymaster postop gas
             uint8((ALLOW_ALL_BUNDLERS & 0x01) | (ERC20_MODE << 1)),
-            uint8((constantFeePresent & 0x01) | (recipientPresent << 1)),
+            uint8(
+                (constantFeePresent == 1 ? 1 : 0) | (recipientPresent == 1 ? 1 << 1 : 0)
+                    | (preFundPresent > 0 ? 1 << 2 : 0)
+            ),
             uint48(0), // validUntil
             int48(0), // validAfter
             address(token), // token
@@ -394,6 +448,13 @@ contract SingletonPaymasterV7Test is Test {
             uint128(0), // paymasterValidationGasLimit
             treasury // treasury
         );
+
+        if (preFundPresent > 0) {
+            op.paymasterAndData = abi.encodePacked(
+                op.paymasterAndData,
+                preFundPresent // preFund
+            );
+        }
 
         if (constantFeePresent == 1) {
             op.paymasterAndData = abi.encodePacked(
@@ -441,12 +502,22 @@ contract SingletonPaymasterV7Test is Test {
         );
         submitUserOp(op);
 
-        test_RevertWhen_PaymasterAndDataLengthInvalid(uint8(0), uint8(1));
-        test_RevertWhen_PaymasterAndDataLengthInvalid(uint8(1), uint8(0));
-        test_RevertWhen_PaymasterAndDataLengthInvalid(uint8(1), uint8(1));
+        test_RevertWhen_PaymasterAndDataLengthInvalid(uint8(0), uint8(1), uint128(0));
+        test_RevertWhen_PaymasterAndDataLengthInvalid(uint8(1), uint8(0), uint128(0));
+        test_RevertWhen_PaymasterAndDataLengthInvalid(uint8(1), uint8(1), uint128(0));
+
+        test_RevertWhen_PaymasterAndDataLengthInvalid(uint8(0), uint8(1), uint128(1_000_000));
+        test_RevertWhen_PaymasterAndDataLengthInvalid(uint8(1), uint8(0), uint128(1_000_000));
+        test_RevertWhen_PaymasterAndDataLengthInvalid(uint8(1), uint8(1), uint128(1_000_000));
     }
 
-    function test_RevertWhen_PaymasterAndDataLengthInvalid(uint8 constantFeePresent, uint8 recipientPresent) internal {
+    function test_RevertWhen_PaymasterAndDataLengthInvalid(
+        uint8 constantFeePresent,
+        uint8 recipientPresent,
+        uint128 preFundPresent
+    )
+        internal
+    {
         PackedUserOperation memory op = fillUserOp();
 
         op.paymasterAndData = abi.encodePacked(
@@ -454,7 +525,10 @@ contract SingletonPaymasterV7Test is Test {
             uint128(100_000), // paymaster verification gas
             uint128(50_000), // paymaster postop gas
             uint8((ALLOW_ALL_BUNDLERS & 0x01) | (ERC20_MODE << 1)),
-            uint8((constantFeePresent & 0x01) | (recipientPresent << 1)),
+            uint8(
+                (constantFeePresent == 1 ? 1 : 0) | (recipientPresent == 1 ? 1 << 1 : 0)
+                    | (preFundPresent > 0 ? 1 << 2 : 0)
+            ),
             uint48(0), // validUntil
             int48(0), // validAfter
             address(token), // token
@@ -500,8 +574,10 @@ contract SingletonPaymasterV7Test is Test {
         submitUserOp(op);
     }
 
-    function test_RevertWhen_InvalidRecipient(uint8 _constantFeePresent) external {
+    function test_RevertWhen_InvalidRecipient(uint8 _constantFeePresent, uint8 _preFundPresent) external {
         uint8 constantFeePresent = uint8(bound(_constantFeePresent, 0, 1));
+        uint128 preFundPresent = uint128(bound(_preFundPresent, 0, 1));
+
         uint8 recipientPresent = uint8(1);
 
         PackedUserOperation memory op = fillUserOp();
@@ -511,7 +587,10 @@ contract SingletonPaymasterV7Test is Test {
             uint128(100_000), // paymaster verification gas
             uint128(50_000), // paymaster postop gas
             uint8((ALLOW_ALL_BUNDLERS & 0x01) | (ERC20_MODE << 1)),
-            uint8((constantFeePresent & 0x01) | (recipientPresent << 1)),
+            uint8(
+                (constantFeePresent == 1 ? 1 : 0) | (recipientPresent == 1 ? 1 << 1 : 0)
+                    | (preFundPresent > 0 ? 1 << 2 : 0)
+            ),
             uint48(0), // validUntil
             int48(0), // validAfter
             address(token), // token
@@ -525,6 +604,13 @@ contract SingletonPaymasterV7Test is Test {
             uint128(0), // paymasterValidationGasLimit
             treasury // treasury
         );
+
+        if (preFundPresent > 0) {
+            op.paymasterAndData = abi.encodePacked(
+                op.paymasterAndData,
+                preFundPresent // preFund
+            );
+        }
 
         if (constantFeePresent == 1) {
             op.paymasterAndData = abi.encodePacked(
@@ -561,7 +647,7 @@ contract SingletonPaymasterV7Test is Test {
         PackedUserOperation memory op = fillUserOp();
 
         op.paymasterAndData =
-            getSignedPaymasterData(ERC20_MODE, ALLOW_ALL_BUNDLERS, op, constantFeePresent, recipientPresent);
+            getSignedPaymasterData(ERC20_MODE, ALLOW_ALL_BUNDLERS, op, constantFeePresent, recipientPresent, uint128(0));
         op.signature = signUserOp(op, userKey);
 
         vm.expectEmit(address(entryPoint));
@@ -573,8 +659,35 @@ contract SingletonPaymasterV7Test is Test {
                 IEntryPoint.PostOpReverted.selector, abi.encodeWithSelector(SafeTransferLib.TransferFromFailed.selector)
             )
         );
+        submitUserOp(op);
+    }
+
+    // Loop hall in the v7 postOp
+    function test_PostOpFirstTransferFromFailed() external {
+        setupERC20Environment();
+
+        // treasury should have no tokens
+        assertEq(token.balanceOf(treasury), 0);
+
+        PackedUserOperation memory op = fillUserOp();
+        op.callData = abi.encodeWithSelector(
+            SimpleAccount.execute.selector,
+            address(token),
+            0,
+            // remove the approve during execution phase
+            abi.encodeWithSelector(TestERC20.sudoApprove.selector, address(account), address(paymaster), 0)
+        );
+        op.paymasterAndData = getSignedPaymasterData(ERC20_MODE, ALLOW_ALL_BUNDLERS, op, uint8(0), uint8(0), uint8(0));
+        op.signature = signUserOp(op, userKey);
+
+        // check that UserOperationSponsored log is emitted.
+        // event data check is skipped because we don't know how much will be spent.
+        vm.expectEmit(true, true, true, false, address(entryPoint));
+        emit IEntryPoint.UserOperationEvent(getOpHash(op), op.sender, address(paymaster), op.nonce, true, 0, 0);
 
         submitUserOp(op);
+
+        assertEq(token.balanceOf(treasury), 0);
     }
 
     // test that the treasury receives funds when postOp is called
@@ -599,7 +712,7 @@ contract SingletonPaymasterV7Test is Test {
         uint128 postOpGas = uint128(bound(_postOpGas, 21_000, 250_000));
         uint256 actualUserOpFeePerGas = bound(_actualUserOpFeePerGas, 0.01 gwei, 5000 gwei);
         uint256 userOperationGasUsed = bound(_userOperationGasUsed, 21_000, 30_000_000);
-        uint256 exchangeRate = bound(_exchangeRate, 1e6, 1e20);
+        uint256 exchangeRate = bound(_exchangeRate, 1e6, 1e24);
         uint128 constantFee = uint128(bound(_constantFee, 1e6, 1e20));
         uint8 constantFeePresent = uint8(bound(_constantFeePresent, 0, 1));
         uint8 recipientPresent = uint8(bound(_recipientPresent, 0, 1));
@@ -619,6 +732,7 @@ contract SingletonPaymasterV7Test is Test {
                 maxFeePerGas: 0,
                 maxPriorityFeePerGas: 0,
                 preFund: preFund,
+                preFundCharged: uint256(0),
                 executionGasLimit: uint256(0),
                 preOpGasApproximation: uint256(0),
                 constantFee: constantFeePresent == 1 ? constantFee : uint128(0),
@@ -671,7 +785,7 @@ contract SingletonPaymasterV7Test is Test {
         uint128 postOpGas = uint128(bound(_postOpGas, 21_000, 250_000));
         uint256 actualUserOpFeePerGas = bound(_actualUserOpFeePerGas, 0.01 gwei, 5000 gwei);
         uint256 userOperationGasUsed = bound(_userOperationGasUsed, 21_000, 30_000_000);
-        uint256 exchangeRate = bound(_exchangeRate, 1e6, 1e20);
+        uint256 exchangeRate = bound(_exchangeRate, 1e6, 1e24);
         uint128 constantFee = uint128(bound(_constantFee, 0, 1000));
         uint8 constantFeePresent = uint8(bound(_constantFeePresent, 0, 1));
         uint8 recipientPresent = uint8(bound(_recipientPresent, 0, 1));
@@ -696,6 +810,7 @@ contract SingletonPaymasterV7Test is Test {
                 preOpGasApproximation: uint256(0),
                 executionGasLimit: uint256(userOperationGasUsed * 2),
                 preFund: preFund,
+                preFundCharged: uint256(0),
                 constantFee: constantFeePresent == 1 ? constantFee : uint128(0),
                 recipient: recipientPresent == 1 ? recipient : address(0)
             })
@@ -733,7 +848,8 @@ contract SingletonPaymasterV7Test is Test {
         assertEq(token.balanceOf(treasury), 0);
 
         PackedUserOperation memory op = fillUserOp();
-        op.paymasterAndData = getSignedPaymasterData(ERC20_MODE, ALLOW_WHITELISTED_BUNDLERS, op, uint8(0), uint8(0));
+        op.paymasterAndData =
+            getSignedPaymasterData(ERC20_MODE, ALLOW_WHITELISTED_BUNDLERS, op, uint8(0), uint8(0), uint8(0));
         op.signature = signUserOp(op, userKey);
 
         // check that UserOperationSponsored log is emitted.
@@ -764,7 +880,8 @@ contract SingletonPaymasterV7Test is Test {
         paymaster.updateBundlerAllowlist(bundlers, true);
 
         PackedUserOperation memory op = fillUserOp();
-        op.paymasterAndData = getSignedPaymasterData(ERC20_MODE, ALLOW_WHITELISTED_BUNDLERS, op, uint8(0), uint8(0));
+        op.paymasterAndData =
+            getSignedPaymasterData(ERC20_MODE, ALLOW_WHITELISTED_BUNDLERS, op, uint8(0), uint8(0), uint8(0));
         op.signature = signUserOp(op, userKey);
 
         // check that UserOperationSponsored log is emitted.
@@ -793,6 +910,37 @@ contract SingletonPaymasterV7Test is Test {
         bytes32 opHash = getOpHash(op);
         vm.expectRevert("Sender not EntryPoint");
         paymaster.validatePaymasterUserOp(op, opHash, 0);
+    }
+
+    function test_RevertWhen_ERC20WithPreFundExceedsRequiredPreFund() external {
+        setupERC20Environment();
+
+        // treasury should have no tokens
+        assertEq(token.balanceOf(treasury), 0);
+
+        PackedUserOperation memory op = fillUserOp();
+        op.paymasterAndData = getSignedPaymasterData(
+            ERC20_MODE,
+            ALLOW_ALL_BUNDLERS,
+            op,
+            uint8(0),
+            uint8(0),
+            uint128(1_000_000_000_000_000_000_000_000_000_000_000)
+        );
+        op.signature = signUserOp(op, userKey);
+
+        // check that UserOperationSponsored log is emitted.
+        // event data check is skipped because we don't know how much will be spent.
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEntryPoint.FailedOpWithRevert.selector,
+                uint256(0),
+                string("AA33 reverted"),
+                abi.encodeWithSelector(BaseSingletonPaymaster.PreFundTooHigh.selector)
+            )
+        );
+        submitUserOp(op);
     }
 
     // context should always be empty when used in verfiying mode
@@ -870,13 +1018,16 @@ contract SingletonPaymasterV7Test is Test {
         uint128 _postOpGas,
         uint256 _exchangeRate,
         uint8 _constantFeePresent,
-        uint8 _recipientPresent
+        uint8 _recipientPresent,
+        uint8 _preFundPresent
     )
         external
     {
         uint8 constantFeePresent = uint8(bound(_constantFeePresent, 0, 1));
         uint8 recipientPresent = uint8(bound(_recipientPresent, 0, 1));
+        uint8 preFundPresent = uint8(bound(_preFundPresent, 0, 1));
         vm.assume(_exchangeRate > 0);
+        vm.assume(_exchangeRate < 1e24);
         vm.assume(_token != address(0));
 
         PackedUserOperation memory op = fillUserOp();
@@ -885,12 +1036,30 @@ contract SingletonPaymasterV7Test is Test {
 
         // Test with correct signature
         validateERC20PaymasterUserOp(
-            op, data, _token, _postOpGas, _exchangeRate, 0, paymasterSignerKey, constantFeePresent, recipientPresent
+            op,
+            data,
+            _token,
+            _postOpGas,
+            _exchangeRate,
+            0,
+            paymasterSignerKey,
+            constantFeePresent,
+            recipientPresent,
+            preFundPresent
         );
 
         // Test with incorrect signature
         validateERC20PaymasterUserOp(
-            op, data, _token, _postOpGas, _exchangeRate, 1, unauthorizedSignerKey, constantFeePresent, recipientPresent
+            op,
+            data,
+            _token,
+            _postOpGas,
+            _exchangeRate,
+            1,
+            unauthorizedSignerKey,
+            constantFeePresent,
+            recipientPresent,
+            preFundPresent
         );
     }
 
@@ -903,10 +1072,16 @@ contract SingletonPaymasterV7Test is Test {
         uint160 expectedSignature,
         uint256 signerKey,
         uint8 constantFeePresent,
-        uint8 recipientPresent
+        uint8 recipientPresent,
+        uint8 preFundPresent
     )
         internal
     {
+        if (preFundPresent > 0) {
+            tokenAddress = address(token);
+            token.sudoMint(address(account), 1e18);
+            token.sudoApprove(address(account), address(paymaster), UINT256_MAX);
+        }
         op.paymasterAndData = getERC20ModeData(
             data,
             tokenAddress,
@@ -916,19 +1091,48 @@ contract SingletonPaymasterV7Test is Test {
             op,
             signerKey,
             constantFeePresent,
-            recipientPresent
+            recipientPresent,
+            preFundPresent
         );
         op.signature = signUserOp(op, userKey);
         bytes32 opHash = getOpHash(op);
 
         vm.prank(address(entryPoint));
-        (bytes memory context, uint256 validationData) = paymaster.validatePaymasterUserOp(op, opHash, 0);
+        uint256 requiredPreFund = 1 * 1e18;
+        (bytes memory context, uint256 validationData) = paymaster.validatePaymasterUserOp(op, opHash, requiredPreFund);
 
         // Validation checks
         vm.assertEq(uint160(validationData), expectedSignature, "unexpected signature");
         vm.assertEq(uint48(validationData >> 160), data.validUntil);
         vm.assertEq(uint48(validationData >> (48 + 160)), data.validAfter);
 
+        validateContext(
+            context,
+            op,
+            tokenAddress,
+            postOpGas,
+            exchangeRate,
+            opHash,
+            constantFeePresent,
+            recipientPresent,
+            preFundPresent
+        );
+    }
+
+    function validateContext(
+        bytes memory context,
+        PackedUserOperation memory op,
+        address tokenAddress,
+        uint128 postOpGas,
+        uint256 exchangeRate,
+        bytes32 opHash,
+        uint8 constantFeePresent,
+        uint8 recipientPresent,
+        uint8 preFundPresent
+    )
+        internal
+        view
+    {
         // Context checks
         ERC20PostOpContext memory ctx = abi.decode(context, (ERC20PostOpContext));
         vm.assertEq(ctx.sender, op.sender, "encoded context sender should equal userOperation.sender");
@@ -938,17 +1142,38 @@ contract SingletonPaymasterV7Test is Test {
         vm.assertEq(ctx.userOpHash, opHash, "encoded context opHash should equal opHash");
         vm.assertEq(ctx.maxFeePerGas, 0, "encoded context maxFeePerGas should equal to 0");
         vm.assertEq(ctx.maxPriorityFeePerGas, 0, "encoded context maxPriorityFeePerGas should equal to 0");
+        vm.assertEq(
+            ctx.constantFee,
+            constantFeePresent == 1 ? uint256(1) : uint256(0),
+            "encoded context constantFee should equal constantFee"
+        );
+        vm.assertEq(
+            ctx.recipient,
+            recipientPresent == 1 ? recipient : address(0),
+            "encoded context recipient should equal recipient"
+        );
+        vm.assertEq(ctx.preFundCharged, preFundPresent, "encoded context preFund should equal preFundPresent");
     }
 
     function testValidateSignatureCorrectness() external {
-        flipUserOperationBitsAndValidateSignature(ERC20_MODE, uint8(0), uint8(0));
-        flipUserOperationBitsAndValidateSignature(VERIFYING_MODE, uint8(0), uint8(0));
+        flipUserOperationBitsAndValidateSignature(ERC20_MODE, uint8(0), uint8(0), uint128(0));
+        flipUserOperationBitsAndValidateSignature(VERIFYING_MODE, uint8(0), uint8(0), uint128(0));
     }
 
     function testValidateSignatureCorrectnessWithConstantFeeAndRecipient() external {
-        flipUserOperationBitsAndValidateSignature(ERC20_MODE, uint8(0), uint8(1));
-        flipUserOperationBitsAndValidateSignature(ERC20_MODE, uint8(1), uint8(0));
-        flipUserOperationBitsAndValidateSignature(ERC20_MODE, uint8(1), uint8(1));
+        flipUserOperationBitsAndValidateSignature(ERC20_MODE, uint8(0), uint8(1), uint128(0));
+        flipUserOperationBitsAndValidateSignature(ERC20_MODE, uint8(1), uint8(0), uint128(0));
+        flipUserOperationBitsAndValidateSignature(ERC20_MODE, uint8(1), uint8(1), uint128(0));
+    }
+
+    function testValidateSignatureCorrectnessWithPreFund() external {
+        flipUserOperationBitsAndValidateSignature(ERC20_MODE, uint8(0), uint8(0), uint128(1));
+    }
+
+    function testValidateSignatureCorrectnessWithConstantFeeAndRecipientAndPreFund() external {
+        flipUserOperationBitsAndValidateSignature(ERC20_MODE, uint8(0), uint8(1), uint128(1));
+        flipUserOperationBitsAndValidateSignature(ERC20_MODE, uint8(1), uint8(0), uint128(1));
+        flipUserOperationBitsAndValidateSignature(ERC20_MODE, uint8(1), uint8(1), uint128(1));
     }
 
     // HELPERS //
@@ -956,16 +1181,26 @@ contract SingletonPaymasterV7Test is Test {
     function flipUserOperationBitsAndValidateSignature(
         uint8 _mode,
         uint8 _constantFeePresent,
-        uint8 _recipientPresent
+        uint8 _recipientPresent,
+        uint128 _preFundPresent
     )
         internal
     {
         PackedUserOperation memory op = fillUserOp();
-        op.paymasterAndData =
-            getSignedPaymasterData(_mode, ALLOW_ALL_BUNDLERS, op, _constantFeePresent, _recipientPresent);
+        op.paymasterAndData = getSignedPaymasterData(
+            _mode, ALLOW_ALL_BUNDLERS, op, _constantFeePresent, _recipientPresent, _preFundPresent
+        );
         op.signature = signUserOp(op, userKey);
 
-        checkIsPaymasterSignatureValid(op, true);
+        uint256 requiredPreFund = 0;
+
+        if (_preFundPresent > 0) {
+            token.sudoMint(address(account), 1000 * 1e18);
+            token.sudoApprove(address(account), address(paymaster), UINT256_MAX);
+            requiredPreFund = 1e18;
+        }
+
+        checkIsPaymasterSignatureValid(op, true, requiredPreFund);
 
         // flip each bit in userOperation and check that signature is invalid
         for (uint256 bitPosition = 0; bitPosition < 256; bitPosition++) {
@@ -973,24 +1208,29 @@ contract SingletonPaymasterV7Test is Test {
 
             if (bitPosition < 160) {
                 op.sender = address(bytes20(op.sender) ^ bytes20(uint160(mask)));
-                checkIsPaymasterSignatureValid(op, false);
+                if (_preFundPresent > 0) {
+                    token.sudoMint(address(op.sender), 3000 * 1e18);
+                    token.sudoApprove(address(op.sender), address(paymaster), UINT256_MAX);
+                    requiredPreFund = 1e18;
+                }
+                checkIsPaymasterSignatureValid(op, false, requiredPreFund);
                 op.sender = address(bytes20(op.sender) ^ bytes20(uint160(mask)));
             }
 
             op.nonce = uint256(bytes32(op.nonce) ^ bytes32(mask));
-            checkIsPaymasterSignatureValid(op, false);
+            checkIsPaymasterSignatureValid(op, false, requiredPreFund);
             op.nonce = uint256(bytes32(op.nonce) ^ bytes32(mask));
 
             op.accountGasLimits = bytes32(op.accountGasLimits) ^ bytes32(mask);
-            checkIsPaymasterSignatureValid(op, false);
+            checkIsPaymasterSignatureValid(op, false, requiredPreFund);
             op.accountGasLimits = bytes32(op.accountGasLimits) ^ bytes32(mask);
 
             op.preVerificationGas = uint256(bytes32(op.preVerificationGas) ^ bytes32(mask));
-            checkIsPaymasterSignatureValid(op, false);
+            checkIsPaymasterSignatureValid(op, false, requiredPreFund);
             op.preVerificationGas = uint256(bytes32(op.preVerificationGas) ^ bytes32(mask));
 
             op.gasFees = bytes32(op.gasFees) ^ bytes32(mask);
-            checkIsPaymasterSignatureValid(op, false);
+            checkIsPaymasterSignatureValid(op, false, requiredPreFund);
             op.gasFees = bytes32(op.gasFees) ^ bytes32(mask);
         }
 
@@ -1000,7 +1240,7 @@ contract SingletonPaymasterV7Test is Test {
                 uint256 mask = 1 << bitPosition;
 
                 op.callData[byteIndex] = bytes1(uint8(op.callData[byteIndex]) ^ uint8(mask));
-                checkIsPaymasterSignatureValid(op, false);
+                checkIsPaymasterSignatureValid(op, false, requiredPreFund);
                 op.callData[byteIndex] = bytes1(uint8(op.callData[byteIndex]) ^ uint8(mask));
             }
         }
@@ -1011,7 +1251,7 @@ contract SingletonPaymasterV7Test is Test {
                 uint256 mask = 1 << bitPosition;
 
                 op.initCode[byteIndex] = bytes1(uint8(op.initCode[byteIndex]) ^ uint8(mask));
-                checkIsPaymasterSignatureValid(op, false);
+                checkIsPaymasterSignatureValid(op, false, requiredPreFund);
                 op.initCode[byteIndex] = bytes1(uint8(op.initCode[byteIndex]) ^ uint8(mask));
             }
         }
@@ -1029,6 +1269,10 @@ contract SingletonPaymasterV7Test is Test {
             if (_recipientPresent == 1) {
                 paymasterConfigLength += 20;
             }
+
+            if (_preFundPresent == 1) {
+                paymasterConfigLength += 16;
+            }
         }
 
         if (_mode == VERIFYING_MODE) {
@@ -1042,7 +1286,7 @@ contract SingletonPaymasterV7Test is Test {
                 continue;
             }
 
-            // don't change constantFeePresent and recipientPresent
+            // don't change constantFeePresent, recipientPresent, preFundPresent
             if (_mode == ERC20_MODE && byteIndex == 53) {
                 continue;
             }
@@ -1051,16 +1295,22 @@ contract SingletonPaymasterV7Test is Test {
                 uint256 mask = 1 << bitPosition;
 
                 op.paymasterAndData[byteIndex] = bytes1(uint8(op.paymasterAndData[byteIndex]) ^ uint8(mask));
-                checkIsPaymasterSignatureValid(op, false);
+                checkIsPaymasterSignatureValid(op, false, requiredPreFund);
                 op.paymasterAndData[byteIndex] = bytes1(uint8(op.paymasterAndData[byteIndex]) ^ uint8(mask));
             }
         }
     }
 
-    function checkIsPaymasterSignatureValid(PackedUserOperation memory op, bool isSignatureValid) internal {
+    function checkIsPaymasterSignatureValid(
+        PackedUserOperation memory op,
+        bool isSignatureValid,
+        uint256 requiredPreFund
+    )
+        internal
+    {
         bytes32 opHash = getOpHash(op);
         vm.prank(address(entryPoint));
-        (, uint256 validationData) = paymaster.validatePaymasterUserOp(op, opHash, 0);
+        (, uint256 validationData) = paymaster.validatePaymasterUserOp(op, opHash, requiredPreFund);
         assertEq(uint160(validationData), isSignatureValid ? 0 : 1);
     }
 
@@ -1069,7 +1319,8 @@ contract SingletonPaymasterV7Test is Test {
         uint8 allowAllBundlers,
         PackedUserOperation memory userOp,
         uint8 constantFeePresent,
-        uint8 recipientPresent
+        uint8 recipientPresent,
+        uint128 preFundPresent
     )
         private
         view
@@ -1096,7 +1347,8 @@ contract SingletonPaymasterV7Test is Test {
                 userOp,
                 paymasterSignerKey,
                 constantFeePresent,
-                recipientPresent
+                recipientPresent,
+                preFundPresent
             );
         }
 
@@ -1135,7 +1387,8 @@ contract SingletonPaymasterV7Test is Test {
         PackedUserOperation memory userOp,
         uint256 signingKey,
         uint8 constantFeePresent,
-        uint8 recipientPresent
+        uint8 recipientPresent,
+        uint128 preFundPresent
     )
         private
         view
@@ -1146,7 +1399,10 @@ contract SingletonPaymasterV7Test is Test {
             data.preVerificationGas,
             data.postOpGas,
             uint8((data.allowAllBundlers & 0x01) | (ERC20_MODE << 1)),
-            uint8((constantFeePresent & 0x01) | (recipientPresent << 1))
+            uint8(
+                (constantFeePresent == 1 ? 1 : 0) | (recipientPresent == 1 ? 1 << 1 : 0)
+                    | (preFundPresent > 0 ? 1 << 2 : 0)
+            )
         );
 
         // split into 2 parts to avoid stack too deep
@@ -1160,6 +1416,10 @@ contract SingletonPaymasterV7Test is Test {
             paymasterValidationGasLimit,
             treasury
         );
+
+        if (preFundPresent > 0) {
+            userOp.paymasterAndData = abi.encodePacked(userOp.paymasterAndData, preFundPresent);
+        }
 
         if (constantFeePresent == 1) {
             uint128 constantFee = 1;
@@ -1217,5 +1477,6 @@ contract SingletonPaymasterV7Test is Test {
         token.sudoMint(address(account), 1000e18);
         token.sudoMint(address(paymaster), 1);
         token.sudoApprove(address(account), address(paymaster), UINT256_MAX);
+        token.sudoApprove(address(treasury), address(paymaster), UINT256_MAX);
     }
 }


### PR DESCRIPTION
1. [HIGH] Fix Users undercharged due to erroneous cost calculation
2. [Medium] User is not charged when first postOp call reverts
3. [Info] Redundant signing of paymaster address
4. [Best Practices] Unused imports
5. [Best Practices] Unnecessary calculation of preFund amount